### PR TITLE
feat: 칸반보드 드래그앤드롭, 컬럼삭제 스토어 연동

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,8 @@
     "class-methods-use-this": "off",
     "no-unused-vars": "off",
     "no-underscore-dangle": "off",
-    "no-bitwise": "off"
+    "no-bitwise": "off",
+    "no-useless-catch": "off",
+    "no-restricted-globals": "off"
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
   <head>
     <meta charset="UTF-8" />
     <title>Vite App</title>
+    <link rel="icon" href="https://i.imgur.com/EP0g7bF.png" />
   </head>
   <body>
     <div id="app"></div>

--- a/src/lib/api/board.js
+++ b/src/lib/api/board.js
@@ -17,3 +17,12 @@ export const apiPostBoard = async ({ id, title }) => {
     return {};
   }
 };
+
+export const apiPutMoveBoard = async ({ nodeId, parentId, targetIndex }) => {
+  try {
+    const response = await request.put('/board/move', { nodeId, parentId, targetIndex });
+    return response.data;
+  } catch (error) {
+    return {};
+  }
+};

--- a/src/lib/api/board.js
+++ b/src/lib/api/board.js
@@ -5,7 +5,16 @@ export const apiGetBoardList = async () => {
     const response = await request.get('/boards');
     return response.data;
   } catch (error) {
-    return [];
+    throw error;
+  }
+};
+
+export const apiDeleteBoardColumn = async (id) => {
+  try {
+    const response = await request.delete(`/boards/${id}`);
+    return response.data;
+  } catch (error) {
+    throw error;
   }
 };
 
@@ -14,7 +23,7 @@ export const apiPostBoard = async ({ id, title }) => {
     const response = await request.post('/board', { id, title });
     return response.data;
   } catch (error) {
-    return {};
+    throw error;
   }
 };
 
@@ -23,6 +32,6 @@ export const apiPutMoveBoard = async ({ nodeId, parentId, targetIndex }) => {
     const response = await request.put('/board/move', { nodeId, parentId, targetIndex });
     return response.data;
   } catch (error) {
-    return {};
+    throw error;
   }
 };

--- a/src/lib/mocks/api.js
+++ b/src/lib/mocks/api.js
@@ -33,4 +33,16 @@ export const mockPostBoard = () =>
     },
   });
 
-export default [mockGetBoards, mockPostBoard];
+export const mockPutMoveBoard = () =>
+  mockServer({
+    method: 'PUT',
+    path: '/api/board/move',
+    statusCode: 200,
+    responseCallback: ({ data }) => {
+      const { nodeId, parentId, targetIndex } = data;
+      mockData.moveBoardItem({ nodeId, parentId, targetIndex });
+      return mockData.getBoards();
+    },
+  });
+
+export default [mockGetBoards, mockPostBoard, mockPutMoveBoard];

--- a/src/lib/mocks/api.js
+++ b/src/lib/mocks/api.js
@@ -45,4 +45,15 @@ export const mockPutMoveBoard = () =>
     },
   });
 
-export default [mockGetBoards, mockPostBoard, mockPutMoveBoard];
+export const mockDeleteBoardColumn = () =>
+  mockServer({
+    method: 'DELETE',
+    path: '/api/boards/:id',
+    statusCode: 200,
+    responseCallback: ({ params }) => {
+      const { id } = params;
+      mockData.removeBoardColumnById(id);
+    },
+  });
+
+export default [mockGetBoards, mockPostBoard, mockPutMoveBoard, mockDeleteBoardColumn];

--- a/src/lib/mocks/mockData.js
+++ b/src/lib/mocks/mockData.js
@@ -1,12 +1,13 @@
 import { uuidv4 } from '../utils/string';
+import { insertBoardItem, removeBoardItem } from '../utils/board';
 
 const getTemplateBoardColumn = (title = '') => ({
   id: uuidv4(),
   title,
   isTextareaOpen: false,
   items: [
-    { id: uuidv4(), title: `제목 ${uuidv4(4)}`, content: [`컨텐츠 ${uuidv4(4)}`], author: 'bytrustu' },
-    { id: uuidv4(), title: `제목 ${uuidv4(4)}`, content: [`컨텐츠 ${uuidv4(4)}`], author: 'bytrustu' },
+    { id: uuidv4(), title: `제목 ${title} - 0`, content: [], author: 'bytrustu' },
+    { id: uuidv4(), title: `제목 ${title} - 1`, content: [], author: 'bytrustu' },
   ],
 });
 
@@ -41,6 +42,12 @@ class MockData {
       const board = getTemplateBoardItem(title);
       this.boards[boardIndex].items.push(board);
     }
+  }
+
+  moveBoardItem({ nodeId, parentId, targetIndex }) {
+    const findBoardItem = [...this.boards.map((board) => board.items).flat()].find((item) => item.id === nodeId);
+    const boardsWithoutItem = removeBoardItem(this.boards, nodeId);
+    this.boards = insertBoardItem(boardsWithoutItem, parentId, findBoardItem, targetIndex);
   }
 }
 

--- a/src/lib/mocks/mockData.js
+++ b/src/lib/mocks/mockData.js
@@ -49,6 +49,10 @@ class MockData {
     const boardsWithoutItem = removeBoardItem(this.boards, nodeId);
     this.boards = insertBoardItem(boardsWithoutItem, parentId, findBoardItem, targetIndex);
   }
+
+  removeBoardColumnById(id) {
+    this.boards = this.boards.filter((data) => data.id !== id);
+  }
 }
 
 const mockData = new MockData();

--- a/src/lib/store/reducer/boardReducer.js
+++ b/src/lib/store/reducer/boardReducer.js
@@ -4,6 +4,7 @@ export const SET_INITIAL_BOARD_ACTION = 'BOARD/SET_INITIAL';
 export const ADD_BOARD_COLUMN_ACTION = 'BOARD/ADD_COLUMN';
 export const ADD_BOARD_ITEM_ACTION = 'BOARD/ADD_ITEM';
 export const MOVE_BOARD_ITEM_ACTION = 'BOARD/MOVE_ITEM';
+export const REMOVE_BOARD_COLUMN_ACTION = 'BOARD/REMOVE_COLUMN';
 export const OPEN_BOARD_TEXTAREA_ACTION = 'BOARD/OPEN_TEXTAREA';
 export const CLOSE_BOARD_TEXTAREA_ACTION = 'BOARD/CLOSE_TEXTAREA';
 
@@ -23,6 +24,11 @@ export const addBoardItemAction = (payload) => ({
 
 export const moveBoardItemAction = (payload) => ({
   type: MOVE_BOARD_ITEM_ACTION,
+  payload,
+});
+
+export const removeBoardColumnAction = (payload) => ({
+  type: REMOVE_BOARD_COLUMN_ACTION,
   payload,
 });
 
@@ -69,6 +75,11 @@ const boardReducer = (state, action) => {
         boards: insertBoardItem(boardsWithoutItem, action.payload.parentId, findBoardItem, action.payload.targetIndex),
       };
     }
+    case REMOVE_BOARD_COLUMN_ACTION:
+      return {
+        ...state,
+        boards: state.boards.filter((board) => board.id !== action.payload),
+      };
     case OPEN_BOARD_TEXTAREA_ACTION:
       return {
         ...state,

--- a/src/lib/store/reducer/boardReducer.js
+++ b/src/lib/store/reducer/boardReducer.js
@@ -1,6 +1,9 @@
+import { insertBoardItem, removeBoardItem } from '../../utils/board';
+
 export const SET_INITIAL_BOARD_ACTION = 'BOARD/SET_INITIAL';
 export const ADD_BOARD_COLUMN_ACTION = 'BOARD/ADD_COLUMN';
 export const ADD_BOARD_ITEM_ACTION = 'BOARD/ADD_ITEM';
+export const MOVE_BOARD_ITEM_ACTION = 'BOARD/MOVE_ITEM';
 export const OPEN_BOARD_TEXTAREA_ACTION = 'BOARD/OPEN_TEXTAREA';
 export const CLOSE_BOARD_TEXTAREA_ACTION = 'BOARD/CLOSE_TEXTAREA';
 
@@ -15,6 +18,11 @@ export const setInitialBoardAction = (payload) => ({
 
 export const addBoardItemAction = (payload) => ({
   type: ADD_BOARD_ITEM_ACTION,
+  payload,
+});
+
+export const moveBoardItemAction = (payload) => ({
+  type: MOVE_BOARD_ITEM_ACTION,
   payload,
 });
 
@@ -53,6 +61,14 @@ const boardReducer = (state, action) => {
           return board;
         }),
       };
+    case MOVE_BOARD_ITEM_ACTION: {
+      const findBoardItem = [...state.boards.map((board) => board.items).flat()].find((item) => item.id === action.payload.nodeId);
+      const boardsWithoutItem = removeBoardItem(state.boards, action.payload.nodeId);
+      return {
+        ...state,
+        boards: insertBoardItem(boardsWithoutItem, action.payload.parentId, findBoardItem, action.payload.targetIndex),
+      };
+    }
     case OPEN_BOARD_TEXTAREA_ACTION:
       return {
         ...state,

--- a/src/lib/utils/board.js
+++ b/src/lib/utils/board.js
@@ -1,0 +1,16 @@
+export const removeBoardItem = (boards, nodeId) =>
+  boards.map((board) => ({
+    ...board,
+    items: board.items.filter((item) => item.id !== nodeId),
+  }));
+
+export const insertBoardItem = (boards, parentId, item, targetIndex) =>
+  boards.map((board) => {
+    if (board.id === parentId) {
+      return {
+        ...board,
+        items: [...board.items.slice(0, targetIndex), item, ...board.items.slice(targetIndex)],
+      };
+    }
+    return board;
+  });

--- a/src/lib/utils/dom.js
+++ b/src/lib/utils/dom.js
@@ -1,0 +1,28 @@
+export const getClosestDraggableNode = (el) => closest(el, '[draggable="true"], .last');
+
+export const closest = (el, selector) => {
+  while (el) {
+    if (el.matches(selector)) {
+      return el;
+    }
+    el = el.parentElement;
+  }
+  return null;
+};
+
+export const getMoveToElementInfo = ($node) => {
+  const $currentNode = $node;
+  const parentNode = closest($node, '[data-type="parent"]');
+  if (!parentNode?.children) {
+    return null;
+  }
+  const findNodeIndex = [...parentNode.children].findIndex((child) => child.dataset.id === $currentNode.dataset.id);
+  if (findNodeIndex !== -1) {
+    return {
+      parentId: parentNode.dataset.id,
+      nodeId: $currentNode.dataset.id,
+      targetIndex: findNodeIndex,
+    };
+  }
+  return null;
+};

--- a/src/lib/utils/initializeDragAndDrop.js
+++ b/src/lib/utils/initializeDragAndDrop.js
@@ -1,26 +1,12 @@
+import { getClosestDraggableNode, getMoveToElementInfo } from './dom';
+
 let $dragNode = null;
 
-function initializeDragAndDrop($container) {
-  $container.addEventListener('dragstart', handleDragStart, true);
-  $container.addEventListener('dragover', handleDragOver, true);
-  $container.addEventListener('dragenter', handleDragEnter, true);
-  $container.addEventListener('dragleave', handleDragLeave, true);
-  $container.addEventListener('drop', handleDrop, true);
-  $container.addEventListener('dragend', handleDragEnd, true);
-}
-
-function closest(el, selector) {
-  while (el) {
-    if (el.matches(selector)) {
-      return el;
-    }
-    el = el.parentElement;
-  }
-  return null;
-}
-
-function getClosestDraggableNode(el) {
-  return closest(el, '[draggable="true"], .last');
+function initializeDragAndDrop($element, callback) {
+  $element.addEventListener('dragstart', handleDragStart, true);
+  $element.addEventListener('dragover', handleDragOver, true);
+  $element.addEventListener('dragenter', handleDragEnter, true);
+  $element.addEventListener('dragend', handleDragEnd.bind(null, callback), true);
 }
 
 function handleDragStart(e) {
@@ -28,7 +14,6 @@ function handleDragStart(e) {
   if (!$target) {
     return;
   }
-
   $dragNode = $target;
   $dragNode.style.opacity = '0.5';
 }
@@ -44,19 +29,11 @@ function handleDragEnter(e) {
     $enterNode.parentNode.insertBefore($dragNode, $enterNode);
   }
 }
-function handleDragLeave(e) {
-  e.preventDefault();
-}
 
-function handleDrop(e) {
-  e.preventDefault();
-
-  console.log('element', getClosestDraggableNode(e.target));
-  console.log('parent element', closest(e.target, '[data-type="parent"]'));
-}
-
-function handleDragEnd(e) {
+function handleDragEnd(callback, e) {
   e.target.style.opacity = '1';
+  const moveElementInfo = getMoveToElementInfo($dragNode);
+  callback(moveElementInfo);
 }
 
 export default initializeDragAndDrop;

--- a/src/lib/utils/timer.js
+++ b/src/lib/utils/timer.js
@@ -1,0 +1,1 @@
+export const forceNextTaskQueue = (callback) => setTimeout(callback, 0);

--- a/src/ui/component/CoreComponent.js
+++ b/src/ui/component/CoreComponent.js
@@ -1,17 +1,10 @@
 import { LitElement } from 'lit';
-import store from '../../lib/store';
 
 class CoreComponent extends LitElement {
   constructor(attributes = []) {
     super();
-    this.store = store;
     this.props = {};
     this.attrs = attributes;
-
-    this.store.subscribe(() => {
-      this.updateState();
-      this.requestUpdate();
-    });
   }
 
   connectedCallback() {
@@ -29,8 +22,6 @@ class CoreComponent extends LitElement {
     }
     return super.shouldUpdate(_changedProperties);
   }
-
-  updateState() {}
 }
 
 export default CoreComponent;

--- a/src/ui/component/board/BoardContainer.js
+++ b/src/ui/component/board/BoardContainer.js
@@ -158,7 +158,6 @@ class BoardContainer extends CoreComponent {
 
   render() {
     const board = JSON.parse(this.props.board);
-    console.log('delete', board);
     return html`
       <section class="board-container">
         <header class="board-container__header">

--- a/src/ui/component/board/BoardList.js
+++ b/src/ui/component/board/BoardList.js
@@ -1,22 +1,42 @@
-import { css, html } from 'lit';
-
-import CoreComponent from '../CoreComponent';
 import initializeDragAndDrop from '../../../lib/utils/initializeDragAndDrop';
+import store from '../../../lib/store';
+import { moveBoardItemAction } from '../../../lib/store/reducer/boardReducer';
+import { apiPutMoveBoard } from '../../../lib/api/board';
+import { forceNextTaskQueue } from '../../../lib/utils/timer';
 
-class BoardList extends CoreComponent {
+class BoardList extends HTMLElement {
   constructor() {
-    super(['id', 'items']);
+    super();
+    this.props = {};
+    this.attachShadow({ mode: 'open' });
+    this.props.initReder = false;
   }
 
-  static get properties() {
-    return {
-      id: { type: String },
-      items: { type: String },
-    };
+  static get observedAttributes() {
+    return ['id', 'items'];
   }
 
-  static get styles() {
-    return css`
+  attributeChangedCallback(name, oldValue, newValue) {
+    this.props[name] = newValue;
+  }
+
+  connectedCallback() {
+    this.render();
+    store.subscribe(() => {
+      forceNextTaskQueue(() => {
+        const storeBoard = store.getState().boards.find((board) => board.id === this.props.id);
+        if (!storeBoard) {
+          return;
+        }
+        this.props.items = storeBoard.items;
+        this.render();
+      });
+    });
+  }
+
+  get styles() {
+    return `
+      <style>
       .board-list__body {
         padding: 0;
         margin: 0;
@@ -100,48 +120,69 @@ class BoardList extends CoreComponent {
         background-color: rgba(128, 128, 128, 0.5);
         border: 2px dashed #000;
       }
+      </style>
     `;
   }
 
-  updated(changedProperties) {
-    const $list = this.shadowRoot.querySelector('.board-list__body');
-    initializeDragAndDrop($list);
+  async moveBoardItemWithAPI(moveElementInfo) {
+    try {
+      await apiPutMoveBoard(moveElementInfo);
+      store.dispatch(moveBoardItemAction(moveElementInfo));
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  initEvent() {
+    forceNextTaskQueue(() => {
+      const $list = this.shadowRoot.querySelector('.board-list__body');
+      if ($list) {
+        initializeDragAndDrop($list, this.moveBoardItemWithAPI);
+        this.props.initReder = true;
+      }
+    });
+  }
+
+  createHTML({ id, items }) {
+    return `
+      <ul class="board-list__body" data-id="${id}" data-type="parent">
+        ${items
+          .map(
+            (item) => `
+              <li class="board-list__item" draggable="true" data-id="${item.id}" key="${item.id}">
+                <figure class="board-list__icon">
+                  <img src="https://i.imgur.com/ZiLeFCC.png" alt="todo" />
+                </figure>
+                <article class="board-list__content">
+                  <h3 class="board-list__content-title">${item.title}</h3>
+                  <footer class="board-list__author">
+                    <span>Added by</span>
+                    <strong>${item.author}</strong>
+                  </footer>
+                </article>
+                <aside class="board-list__item-footer">
+                  <icon-button icon="addIcon" alt="close" @icon-button-click="${this.handleButtonClick}"></icon-button>
+                </aside>
+              </li>
+            `,
+          )
+          .join('')}
+        <li class="board-list__item last"></li>
+      </ul>
+    `;
   }
 
   render() {
     const { id } = this.props;
-    const items = JSON.parse(this.props.items);
+    const items = typeof this.props.items === 'string' ? JSON.parse(this.props.items) : this.props.items;
 
-    return html`
-      <ul class="board-list__body" data-id="${id}" data-type="parent">
-        ${items.map(
-          (item, index) => html`
-            <li class="board-list__item" draggable="true" data-id="${item.id}">
-              <figure class="board-list__icon">
-                <img src="https://i.imgur.com/ZiLeFCC.png" alt="todo" />
-              </figure>
-              <article class="board-list__content">
-                <h3 class="board-list__content-title">${item.title}</h3>
-                ${item.content.length > 0
-                  ? html`
-                      <ul class="board-list__content-items">
-                        ${item.content.map((content) => html`<li>${content}</li>`)}
-                      </ul>
-                    `
-                  : undefined}
-                <footer class="board-list__author">
-                  <span>Added by</span>
-                  <strong>${item.author}</strong>
-                </footer>
-              </article>
-              <aside class="board-list__item-footer">
-                <icon-button icon="addIcon" alt="close" @icon-button-click="${this.handleButtonClick}"></icon-button>
-              </aside>
-            </li>
-          `,
-        )}
-        <li class="board-list__item last"></li>
-      </ul>
+    console.log('>>>>> end', id, items);
+
+    this.initEvent();
+
+    this.shadowRoot.innerHTML = `
+      ${this.styles}
+      ${this.createHTML({ id, items })}
     `;
   }
 }

--- a/src/ui/component/layout/PageLayout.js
+++ b/src/ui/component/layout/PageLayout.js
@@ -7,10 +7,6 @@ class PageLayout extends CoreComponent {
     super(['boards']);
   }
 
-  static properties = {
-    boards: { type: Array },
-  };
-
   static get styles() {
     return css`
       .page-layout {
@@ -27,6 +23,10 @@ class PageLayout extends CoreComponent {
       }
     `;
   }
+
+  static properties = {
+    boards: { type: Array },
+  };
 
   connectedCallback() {
     super.connectedCallback();

--- a/src/ui/component/layout/PageLayout.js
+++ b/src/ui/component/layout/PageLayout.js
@@ -7,6 +7,10 @@ class PageLayout extends CoreComponent {
     super(['boards']);
   }
 
+  static properties = {
+    boards: { type: Array },
+  };
+
   static get styles() {
     return css`
       .page-layout {
@@ -24,9 +28,16 @@ class PageLayout extends CoreComponent {
     `;
   }
 
+  connectedCallback() {
+    super.connectedCallback();
+    store.subscribe(() => {
+      this.boards = store.getState().boards;
+      this.requestUpdate();
+    });
+  }
+
   render() {
     const { boards } = store.getState();
-    console.log('init board', boards);
     return html`
       <div class="page-layout">
         <page-header></page-header>


### PR DESCRIPTION
## 작업 주제

- #10 

## optional 작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- Board Item 드래그로 위치를 이동할 경우 API, Store에 반영 b9d6fc0fbb98eea72341688936710a73ba65d393 
- 드래그앤드롭의 dragEnd 일 경우 callback으로 드래그 정보를 전달 할 수 있도록 개선 b957e8594f2184c22b3167031cbf72ab9c950817
- Board Column 삭제 기능 추가 6e70cb6654664f72cf91c99895f3b89272a8ea1b
- 드래그 요소에 따른 UI 개선 66f1b25c86c62c92d0c85d9e11cd204f9de10301 d00e12a108113ae81e33920c4fbe0d41d5d5945c
  - BoardList.js 는 Lit을 적용하여 반영했었는데, render 함수에서 데이터는 제대로 전달되고 있는데 
  UI 변경사항이 제대로 반영되지 않아 WebComponent로 반영했습니다. 
  (여러방면으로 수정해보려고 했는데 잘 안되어서, Lit을 제외하고 컴포넌트 내에 store를 subscribe로직을 넣어서 처리했습니다.)

## optional 화면 스크린샷

https://user-images.githubusercontent.com/39726717/230618146-c70c4c16-f86c-4088-bd70-e0591e8bfc38.mp4

## optional 추가 코멘트

- Board Column을 삭제하는 경우, 모달을 아직 구현하지 않아 confirm으로 처리했습니다!

## 체크리스트(PR 올리기 전 아래의 내용을 확인해주세요.)

- [x] base, compare branch가 적절하게 선택되었나요?
- [x] 로컬 환경에서 충분히 테스트 하셨나요?

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
